### PR TITLE
Add Electrum light wallet documentation for BTC and LTC

### DIFF
--- a/docs/about/under-the-hood.md
+++ b/docs/about/under-the-hood.md
@@ -141,7 +141,7 @@ The SMSG network enables BasicSwap to offer functionality beyond what atomic swa
 * Automating complex swap procedures from the user's perspective
 * Facilitating secure communication between independent blockchain networks
 
-In practice, BasicSwap functions as a decentralized alternative to SWIFT—providing a messaging protocol that enables direct peer-to-peer communication for executing atomic swaps using official coin cores (Bitcoin Core, Litecoin Core, etc.).
+In practice, BasicSwap functions as a decentralized alternative to SWIFT in that it provides a messaging protocol that enables direct peer-to-peer communication for executing atomic swaps using official coin cores (Bitcoin Core, Litecoin Core, etc.) or [Electrum light wallets](/docs/user-guides/electrum) for supported coins (currently Bitcoin and Litecoin).
 
 It's important to understand that BasicSwap itself does not process, initiate, or execute the actual swaps. Its role is strictly limited to enabling secure communication between trading parties and simplifying the complex process of performing atomic swaps across different blockchains.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -170,8 +170,8 @@ BasicSwap's primary function is to help users establish a secure communication c
 <Tabs>
   <TabItem value="bitcoin" label="Bitcoin & Forks" default>
     <ul>
-      <li><strong>Bitcoin (BTC)</strong> - The original cryptocurrency</li>
-      <li><strong>Litecoin (LTC)</strong> - Faster and cheaper Bitcoin alternative with privacy</li>
+      <li><strong>Bitcoin (BTC)</strong> - The original cryptocurrency (supports <a href="/docs/user-guides/electrum">light wallet mode</a>)</li>
+      <li><strong>Litecoin (LTC)</strong> - Faster and cheaper Bitcoin alternative with privacy (supports <a href="/docs/user-guides/electrum">light wallet mode</a>)</li>
       <li><strong>Bitcoin Cash (BCC)</strong> - Bitcoin fork focused on payments</li>
       <li><strong>Dogecoin (DOGE)</strong> - Bitcoin with dogs</li>
       <li><strong>Namecoin (NMC)</strong> - Decentralized DNS and public key infrastructure</li>

--- a/docs/user-guides/electrum.md
+++ b/docs/user-guides/electrum.md
@@ -1,0 +1,255 @@
+---
+sidebar_position: 3
+title: Electrum Light Wallets
+description: "How to use Electrum light wallets instead of full nodes for Bitcoin and Litecoin on BasicSwap DEX"
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import React from 'react';
+
+# Electrum Light Wallets
+
+BasicSwap supports **Electrum light wallets** as an alternative to running full blockchain nodes for **Bitcoin (BTC)** and **Litecoin (LTC)**. Instead of downloading and syncing an entire blockchain, Electrum mode connects to remote ElectrumX servers to query blockchain data, letting you start trading much faster with significantly lower disk and bandwidth requirements.
+
+:::info
+Electrum light wallet mode is currently available for **Bitcoin** and **Litecoin** only. All other coins still require full nodes.
+:::
+
+## How It Works
+
+In standard (RPC) mode, BasicSwap runs a full node for each enabled coin — downloading the entire blockchain and verifying every transaction locally. This provides maximum security and trustlessness but requires significant disk space and sync time.
+
+In **Electrum mode**, BasicSwap connects to remote ElectrumX servers using the standardized ElectrumX protocol. These servers index the blockchain and respond to balance, transaction, and UTXO queries on your behalf. Your wallet keys remain local — only public address information is sent to the server.
+
+### Trade-offs
+
+| | Full Node (RPC) | Electrum Light Wallet |
+|---|---|---|
+| **Blockchain download** | Full chain required | None |
+| **Disk space** | Significant (hundreds of GB for BTC) | Minimal |
+| **Setup time** | Hours to days (initial sync) | Seconds |
+| **Trust model** | Fully trustless — you verify everything | Trusts the Electrum server to provide accurate data |
+| **Privacy** | Maximum — no third party sees your queries | Server can see which addresses you query |
+| **Availability** | Independent — your own node | Depends on server availability (auto-failover built in) |
+
+## Supported Coins
+
+Only the following coins currently support Electrum mode:
+
+- **Bitcoin (BTC)**
+- **Litecoin (LTC)**
+
+All other coins (Monero, Particl, Firo, PIVX, Dash, etc.) require full nodes.
+
+## Enable Electrum Mode
+
+There are multiple ways to enable Electrum light wallet mode, depending on whether you are setting up BasicSwap for the first time or modifying an existing installation.
+
+### During Initial Setup
+
+You can enable Electrum mode when first configuring BasicSwap by adding the `--light` flag to the `basicswap-prepare` command. This enables Electrum for all supported coins (BTC and LTC).
+
+<Tabs groupId="setup-method">
+  <TabItem value="docker" label="Docker" default>
+    ```bash title="Terminal"
+    docker run --rm -t --name swap_prepare -v $COINDATA_PATH:/coindata i_swapclient basicswap-prepare --datadir=/coindata --withcoins=monero,bitcoin --htmlhost="0.0.0.0" --wshost="0.0.0.0" --xmrrestoreheight=$CURRENT_XMR_HEIGHT --light
+    ```
+  </TabItem>
+  <TabItem value="no-docker" label="Without Docker">
+    ```bash title="Terminal"
+    basicswap-prepare --datadir=$SWAP_DATADIR --withcoins=monero,bitcoin --xmrrestoreheight=$CURRENT_XMR_HEIGHT --light
+    ```
+  </TabItem>
+</Tabs>
+
+To enable Electrum for a specific coin only, use the per-coin mode flags instead:
+
+<Tabs groupId="setup-method">
+  <TabItem value="docker" label="Docker" default>
+    ```bash title="Terminal"
+    docker run --rm -t --name swap_prepare -v $COINDATA_PATH:/coindata i_swapclient basicswap-prepare --datadir=/coindata --withcoins=monero,bitcoin,litecoin --htmlhost="0.0.0.0" --wshost="0.0.0.0" --xmrrestoreheight=$CURRENT_XMR_HEIGHT --btc-mode=electrum --ltc-mode=electrum
+    ```
+  </TabItem>
+  <TabItem value="no-docker" label="Without Docker">
+    ```bash title="Terminal"
+    basicswap-prepare --datadir=$SWAP_DATADIR --withcoins=monero,bitcoin,litecoin --xmrrestoreheight=$CURRENT_XMR_HEIGHT --btc-mode=electrum --ltc-mode=electrum
+    ```
+  </TabItem>
+</Tabs>
+
+You can also specify a custom Electrum server during setup:
+
+```bash title="Terminal"
+basicswap-prepare --datadir=$SWAP_DATADIR --withcoins=bitcoin --btc-mode=electrum --btc-electrum-server=custom.server.com:50002:true
+```
+
+The server format is `host:port[:ssl]`, where `ssl` is `true` (default) or `false`.
+
+### Via the Web UI
+
+You can switch an existing coin to Electrum mode through the BasicSwap Settings page:
+
+1. Navigate to **Settings** in the BasicSwap web interface.
+2. Locate the coin you want to switch (Bitcoin or Litecoin).
+3. Change the **Connection Type** dropdown from `rpc` to `electrum`.
+4. (Optional) Configure custom Electrum servers in the server list fields.
+5. (Optional) Toggle **Auto-transfer on mode switch** (enabled by default).
+6. (Optional) Adjust the **Address Gap Limit** (default: 20).
+7. Click **Apply** to save changes.
+
+:::warning
+You cannot switch connection modes while the coin has active swaps in progress. Complete or cancel all pending swaps before switching.
+:::
+
+### Via Configuration File
+
+You can manually edit the `basicswap_settings.json` file to enable Electrum mode:
+
+1. Stop BasicSwap.
+2. Open `basicswap_settings.json` in a text editor (located in your data directory).
+3. Under the coin's `chainclients` section, set the following:
+
+```json title="basicswap_settings.json"
+{
+  "chainclients": {
+    "bitcoin": {
+      "connection_type": "electrum",
+      "manage_daemon": false
+    }
+  }
+}
+```
+
+4. Restart BasicSwap.
+
+## Switching Between Modes
+
+You can switch between full node (RPC) and Electrum mode at any time, provided there are no active swaps for that coin.
+
+### Automatic Fund Transfer
+
+By default, **auto-transfer on mode switch** is enabled. When you switch modes, BasicSwap will automatically sweep your funds from the old wallet to the new one:
+
+- **RPC → Electrum:** Funds are swept from your full node wallet to Electrum-derived addresses.
+- **Electrum → RPC:** Funds are swept from Electrum addresses back to your full node wallet.
+
+A standard network fee is deducted from the sweep transaction.
+
+### Manual Fund Transfer
+
+If you disable auto-transfer (`auto_transfer_on_mode_switch: false`), you must manually move your funds between wallets when switching modes. Your old wallet's funds will not be accessible from the new mode until transferred.
+
+## Custom Electrum Servers
+
+BasicSwap ships with a set of default Electrum servers for each supported coin. You can configure custom servers for additional control or privacy.
+
+### Default Servers
+
+<Tabs>
+  <TabItem value="btc-servers" label="Bitcoin" default>
+    | Server | Port | SSL |
+    |--------|------|-----|
+    | bitcoin.stackwallet.com | 50002 | Yes |
+    | electrum.blockstream.info | 50002 | Yes |
+    | electrum.emzy.de | 50002 | Yes |
+    | electrum.bitaroo.net | 50002 | Yes |
+    | electrum.acinq.co | 50002 | Yes |
+    | btc.lastingcoin.net | 50002 | Yes |
+  </TabItem>
+  <TabItem value="ltc-servers" label="Litecoin">
+    | Server | Port | SSL |
+    |--------|------|-----|
+    | litecoin.stackwallet.com | 20063 | Yes |
+    | electrum-ltc.bysh.me | 50002 | Yes |
+    | electrum.ltc.xurious.com | 50002 | Yes |
+    | backup.electrum-ltc.org | 443 | Yes |
+    | ltc.rentonisk.com | 50002 | Yes |
+    | electrum-ltc.petrkr.net | 60002 | Yes |
+    | electrum.jochen-hoenicke.de | 50004 | Yes |
+  </TabItem>
+</Tabs>
+
+### Server Format
+
+Servers are specified in `host:port:ssl` format:
+
+- `bitcoin.stackwallet.com:50002:true` — SSL enabled (default)
+- `my-server.local:50001:false` — SSL disabled
+
+### Configuring Custom Servers
+
+**Via the Web UI:** Navigate to Settings, select the coin, and enter your servers in the clearnet or onion server text fields (one per line).
+
+**Via configuration file:** Add the `electrum_clearnet_servers` and/or `electrum_onion_servers` lists to the coin's section in `basicswap_settings.json`:
+
+```json title="basicswap_settings.json"
+{
+  "chainclients": {
+    "bitcoin": {
+      "connection_type": "electrum",
+      "manage_daemon": false,
+      "electrum_clearnet_servers": [
+        "bitcoin.stackwallet.com:50002:true",
+        "electrum.blockstream.info:50002:true"
+      ],
+      "electrum_onion_servers": [
+        "your-onion-server.onion:50001:false"
+      ]
+    }
+  }
+}
+```
+
+## Tor Integration
+
+Electrum mode fully supports Tor for enhanced privacy.
+
+When Tor is enabled on your BasicSwap instance:
+
+1. **Onion servers are prioritized** — if you have `.onion` Electrum servers configured, they will be used first.
+2. **Clearnet servers are routed through Tor** — if no onion servers are available, clearnet servers are accessed through a SOCKS5 Tor proxy.
+3. **SSL is automatically disabled over Tor** — Tor already provides end-to-end encryption, so the additional SSL layer is unnecessary.
+
+No additional configuration is needed beyond enabling Tor on your BasicSwap instance and optionally adding `.onion` servers to your Electrum server list.
+
+## Monitoring Electrum Wallets
+
+When a coin is running in Electrum mode, the **Wallets** page in the BasicSwap web interface displays different information than in full node mode:
+
+- **Connected Server** — the hostname and port of the currently connected Electrum server.
+- **Server Version** — the version of the ElectrumX server.
+- **Connection Status** — one of the following:
+  - `connected` — successfully connected and operational.
+  - `disconnected` — temporarily disconnected; BasicSwap will automatically attempt reconnection.
+  - `all_failed` — all configured servers have failed. Check your server list and network connectivity.
+
+Unlike full node mode, there is no blockchain sync progress bar — Electrum wallets are ready as soon as a server connection is established.
+
+### Server Health & Failover
+
+BasicSwap automatically monitors server health and handles failover:
+
+- Servers are pinged at regular intervals to detect failures.
+- If a server becomes unresponsive, BasicSwap automatically switches to another available server.
+- Rate-limited servers are temporarily blacklisted (5 minute backoff).
+- Server performance is tracked to prioritize faster, more reliable servers.
+
+## Configuration Reference
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `connection_type` | string | `"rpc"` | Set to `"electrum"` to enable light wallet mode |
+| `manage_daemon` | bool | `true` | Must be `false` when using Electrum mode |
+| `electrum_clearnet_servers` | list | (built-in defaults) | Custom clearnet servers in `host:port:ssl` format |
+| `electrum_onion_servers` | list | `[]` | Custom `.onion` servers for Tor |
+| `electrum_poll_interval` | int | `10` | Polling interval in seconds for wallet updates |
+| `auto_transfer_on_mode_switch` | bool | `true` | Automatically sweep funds when switching between RPC and Electrum |
+| `address_gap_limit` | int | `20` | BIP44 gap limit for address derivation and discovery |
+
+## Limitations
+
+- **Supported coins:** Only Bitcoin and Litecoin. All other coins require full nodes.
+- **Trust model:** Electrum mode trusts the remote server to provide accurate blockchain data. For maximum trustlessness, use full node (RPC) mode.
+- **Litecoin MWEB:** MWEB addresses (starting with `ltcmweb1`) are not supported in Electrum mode. Use standard Litecoin addresses.
+- **Server availability:** If all configured servers are down, wallet operations will be unavailable until a server becomes reachable. Built-in failover minimizes this risk.

--- a/docs/user-guides/enable-disable-coins.md
+++ b/docs/user-guides/enable-disable-coins.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 title: Enable or Disable Coins
 description: "How to enable or disable coins on your BasicSwap DEX instance"
 ---
@@ -31,10 +31,17 @@ If you've built BasicSwap using the Docker method, follow these steps to enable 
     ```
     
     2. Add a cryptocurrency to your BasicSwap instance by running the command below, replacing bitcoin with the specific coin you wish to enable after the `--addcoin` parameter.
-    
+
     ```bash title="Terminal"
     docker-compose run --rm swapclient basicswap-prepare --datadir=/coindata --addcoin=bitcoin
     ```
+
+    :::tip
+    When adding **Bitcoin** or **Litecoin**, you can enable [Electrum light wallet mode](/docs/user-guides/electrum) to avoid downloading their full blockchains. Add `--btc-mode=electrum` or `--ltc-mode=electrum` to the command:
+    ```bash title="Terminal"
+    docker-compose run --rm swapclient basicswap-prepare --datadir=/coindata --addcoin=bitcoin --btc-mode=electrum
+    ```
+    :::
 
     :::tip
     You can copy an existing pruned datadir (excluding `bitcoin.conf` and any wallets) over to `$COINDATA_PATH/bitcoin`. Remove any existing wallets after copying over a pruned chain, or the Bitcoin daemon won't start.
@@ -74,14 +81,21 @@ Linux users can simplify the process of adding and removing coins with community
     1. Stop BasicSwap completely.
 
     2. Add a cryptocurrency to your BasicSwap instance by running the command below, replacing bitcoin with the specific coin you wish to enable after the `--addcoin` parameter.
-    
-    ```bash title="Terminal" 
+
+    ```bash title="Terminal"
     basicswap-prepare --usebtcfastsync --datadir=$SWAP_DATADIR --addcoin=bitcoin
     ```
 
+    :::tip
+    When adding **Bitcoin** or **Litecoin**, you can enable [Electrum light wallet mode](/docs/user-guides/electrum) to avoid downloading their full blockchains. Add `--btc-mode=electrum` or `--ltc-mode=electrum` to the command:
+    ```bash title="Terminal"
+    basicswap-prepare --datadir=$SWAP_DATADIR --addcoin=bitcoin --btc-mode=electrum
+    ```
+    :::
+
     3. Apply the changes to your BasicSwap instance.
-    
-    ```bash title="Terminal" 
+
+    ```bash title="Terminal"
     . $SWAP_DATADIR/venv/bin/activate && python -V
     ```
 

--- a/docs/user-guides/install.md
+++ b/docs/user-guides/install.md
@@ -58,7 +58,7 @@ Watch particularly for permission issues, dependency failures, or network connec
 
 ## Install Using Docker
 
-BasicSwap is currently in beta stage and doesn't offer pre-compiled executables or integrations with third-party services (upcoming). You'll need to compile the source code and run a full node on your device. 
+BasicSwap is currently in beta stage and doesn't offer pre-compiled executables or integrations with third-party services (upcoming). You'll need to compile the source code and run a full node on your device for most coins. However, **Bitcoin and Litecoin** support an optional [Electrum light wallet mode](/docs/user-guides/electrum) that eliminates the need to sync their full blockchains.
 
 ### Install Docker
 
@@ -230,24 +230,26 @@ After creating BasicSwap's Docker image, it's time to configure it to your prefe
 
     5. Determine whether you want to use fast synchronization for the Bitcoin blockchain by including the `--usebtcfastsync` parameter. Fast sync uses checkpoints to reduce initial setup time significantly.
 
-    6. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+    6. **(Optional)** To use [Electrum light wallets](/docs/user-guides/electrum) instead of full nodes for Bitcoin and/or Litecoin, add the `--light` flag (enables Electrum for all supported coins) or use per-coin flags like `--btc-mode=electrum` or `--ltc-mode=electrum`.
 
-    7. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
-    
+    7. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+
+    8. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
+
     ```bash title="Terminal"
     docker run --rm -t --name swap_prepare -v $COINDATA_PATH:/coindata i_swapclient basicswap-prepare --datadir=/coindata --withcoins=monero,bitcoin --htmlhost="0.0.0.0" --wshost="0.0.0.0" --xmrrestoreheight=$CURRENT_XMR_HEIGHT --usebtcfastsync
     ```
 
-    8. Note down and store the mnemonic provided by the above command in a safe place. It serves as your backup key and is valid for all enabled coins.
+    9. Note down and store the mnemonic provided by the above command in a safe place. It serves as your backup key and is valid for all enabled coins.
 
-    9. Note down the result of the following command, it will speed up the process of recovering your Monero if needed. 
-    
+    10. Note down the result of the following command, it will speed up the process of recovering your Monero if needed.
+
     ```bash title="Terminal"
     echo $CURRENT_XMR_HEIGHT
     ```
 
-    10. **(Optional)** Adjust your timezone by specifying the appropriate `TZ` value in your `.env` file, located within the BasicSwap Docker directory. Use the `timedatectl list-timezones` command to view valid timezone options.
-    
+    11. **(Optional)** Adjust your timezone by specifying the appropriate `TZ` value in your `.env` file, located within the BasicSwap Docker directory. Use the `timedatectl list-timezones` command to view valid timezone options.
+
     ```bash title="Terminal"
     nano .env
     ```
@@ -256,15 +258,15 @@ After creating BasicSwap's Docker image, it's time to configure it to your prefe
   </TabItem>
   <TabItem value="linux" label="Linux">
     1. Open a terminal.
-    
+
     2. Navigate to BasicSwap's Docker folder.
-    
+
     ```bash title="Terminal"
     cd basicswap/docker/
     ```
 
     3. Set `xmrrestoreheight` to Monero's current chain height.
-    
+
     ```bash title="Terminal"
     CURRENT_XMR_HEIGHT=$(curl -s http://node2.monerodevs.org:18089/get_info | jq .height)
     ```
@@ -273,10 +275,12 @@ After creating BasicSwap's Docker image, it's time to configure it to your prefe
 
     5. Determine whether you want to use fast synchronization for the Bitcoin blockchain by including the `--usebtcfastsync` parameter. Fast sync uses checkpoints to reduce initial setup time significantly.
 
-    6. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+    6. **(Optional)** To use [Electrum light wallets](/docs/user-guides/electrum) instead of full nodes for Bitcoin and/or Litecoin, add the `--light` flag (enables Electrum for all supported coins) or use per-coin flags like `--btc-mode=electrum` or `--ltc-mode=electrum`.
 
-    7. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
-    
+    7. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+
+    8. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
+
     ```bash title="Terminal"
     docker run --rm -t --name swap_prepare -v $COINDATA_PATH:/coindata i_swapclient basicswap-prepare --datadir=/coindata --withcoins=monero,bitcoin --htmlhost="0.0.0.0" --wshost="0.0.0.0" --xmrrestoreheight=$CURRENT_XMR_HEIGHT --usebtcfastsync
     ```
@@ -446,10 +450,12 @@ Once the installation is complete, configure BasicSwap according to your require
 
     5. Determine whether you want to use fast synchronization for the Bitcoin blockchain by including the `--usebtcfastsync` parameter. Fast sync uses checkpoints to reduce initial setup time significantly.
 
-    6. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+    6. **(Optional)** To use [Electrum light wallets](/docs/user-guides/electrum) instead of full nodes for Bitcoin and/or Litecoin, add the `--light` flag (enables Electrum for all supported coins) or use per-coin flags like `--btc-mode=electrum` or `--ltc-mode=electrum`.
 
-    7. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
-    
+    7. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+
+    8. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
+
     ```bash title="Terminal"
     basicswap-prepare --datadir=$SWAP_DATADIR --withcoins=monero,bitcoin --xmrrestoreheight=$CURRENT_XMR_HEIGHT --usebtcfastsync
     ```
@@ -458,13 +464,13 @@ Once the installation is complete, configure BasicSwap according to your require
     1. Open a terminal.
 
     2. Navigate to your BasicSwap folder.
-    
+
     ```bash title="Terminal"
     cd $HOME/coinswaps
     ```
 
     3. Set `xmrrestoreheight` to Monero's current chain height.
-    
+
     ```bash title="Terminal"
     CURRENT_XMR_HEIGHT=$(curl -s http://node2.monerodevs.org:18089/get_info | jq .height)
     ```
@@ -473,10 +479,12 @@ Once the installation is complete, configure BasicSwap according to your require
 
     5. Determine whether you want to use fast synchronization for the Bitcoin blockchain by including the `--usebtcfastsync` parameter. Fast sync uses checkpoints to reduce initial setup time significantly.
 
-    6. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+    6. **(Optional)** To use [Electrum light wallets](/docs/user-guides/electrum) instead of full nodes for Bitcoin and/or Litecoin, add the `--light` flag (enables Electrum for all supported coins) or use per-coin flags like `--btc-mode=electrum` or `--ltc-mode=electrum`.
 
-    7. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
-    
+    7. Append `--client-auth-password=<YOUR_PASSWORD>` to the below command to optionally enable client authentication to protect your web UI and API port access from unauthorized access.
+
+    8. Execute the following command to configure your BasicSwap, adjusting it according to your preferences as described above.
+
     ```bash title="Terminal"
     basicswap-prepare --datadir=$SWAP_DATADIR --withcoins=monero,bitcoin --xmrrestoreheight=$CURRENT_XMR_HEIGHT --usebtcfastsync
     ```

--- a/docs/user-guides/integrate-coin.md
+++ b/docs/user-guides/integrate-coin.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 title: Integrate a Coin
 description: "How to add your coin to the BasicSwap DEX"
 ---

--- a/docs/user-guides/make-offer.md
+++ b/docs/user-guides/make-offer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: Make an Offer
 description: "How to make and manage trading offers on BasicSwap DEX"
 ---

--- a/docs/user-guides/manage-enabled-coins.md
+++ b/docs/user-guides/manage-enabled-coins.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 title: Manage Enabled Coins
 description: "How to manage enabled coins on BasicSwap DEX"
 ---
@@ -10,12 +10,12 @@ import React from 'react';
 
 # Manage Enabled Coins
 
-BasicSwap DEX operates as a fully non-custodial exchange, giving you complete control over your assets throughout the trading process. This architecture provides significant security and privacy advantages but requires running a full node for each cryptocurrency you enable.
+BasicSwap DEX operates as a fully non-custodial exchange, giving you complete control over your assets throughout the trading process. This architecture provides significant security and privacy advantages but requires running a full node for most enabled cryptocurrencies. Bitcoin and Litecoin also support an optional [Electrum light wallet mode](/docs/user-guides/electrum) as a lightweight alternative to full nodes.
 
 This comprehensive guide explains all aspects of coin management within the BasicSwap environment, from enabling currencies to monitoring blockchain synchronization and managing wallets.
 
 :::info
-In the current beta release, BasicSwap requires running full blockchain nodes locally for each enabled cryptocurrency. Solutions such as light nodes and third-party integrations are being considered and/or worked on by our community of open-source contributors and should eventually go live.  
+Most coins require running full blockchain nodes locally. However, **Bitcoin** and **Litecoin** support [Electrum light wallet mode](/docs/user-guides/electrum), which connects to remote ElectrumX servers instead of downloading the full blockchain. Light wallet support for additional coins is being considered by the community of open-source contributors.
 :::
 
 ## Enable Coins
@@ -28,7 +28,11 @@ To trade with additional cryptocurrencies such as Bitcoin, Litecoin, or Monero, 
 
 When operating BasicSwap, your device functions as a full node for each enabled cryptocurrency (such as Bitcoin), requiring complete blockchain synchronization before trading.
 
-To check current synchronization progress:
+:::tip
+Coins running in [Electrum light wallet mode](/docs/user-guides/electrum) (available for Bitcoin and Litecoin) do not require blockchain synchronization. They connect to remote Electrum servers and are ready to use as soon as a server connection is established. The wallet page will show the connected server and connection status instead of a sync progress bar.
+:::
+
+To check current synchronization progress for full node coins:
 
 1. Access the Wallets page by selecting the `Wallets` tab on the BasicSwap interface.
 

--- a/docs/user-guides/market-making.md
+++ b/docs/user-guides/market-making.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: GUI-Based Automated Market Making
 description: "How to use the integrated automated market making (AMM) tool in the BasicSwap DEX GUI."
 ---

--- a/docs/user-guides/take-offer.md
+++ b/docs/user-guides/take-offer.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Take an Offer
 description: "How to take trading offers on BasicSwap DEX"
 ---


### PR DESCRIPTION
## Summary

- Adds a new **Electrum Light Wallets** guide covering setup pathways (CLI flags, Web UI, config file), custom server configuration, Tor integration, mode switching, monitoring, limitations, etc
- Updates **install.md** to mention the `--light` and `--btc-mode=electrum` / `--ltc-mode=electrum` flags in all configure sections (in both Docker and non-Docker)
- Updates **enable-disable-coins.md** to add Electrum mode tips when adding BTC or LTC
- Updates **manage-enabled-coins.md** to replace the outdated "light nodes being considered" language with current Electrum availability, and adds a sync status note for Electrum wallets
- Updates **intro.md** to note light wallet support next to BTC and LTC in the Compatible Coins list
- Updates **under-the-hood.md** to mention Electrum as an alternative to full coin cores